### PR TITLE
When calculating lastIndex do numeric addition instead of string concatenation.

### DIFF
--- a/lit-pagination.js
+++ b/lit-pagination.js
@@ -232,7 +232,7 @@ class LitPagination extends LitElement{
     }
 
     _lastIndex(page, size) {
-        let index = page + size;
+        let index = parseInt(page) + parseInt(size);
         if (index > this.pages) {
             return this.pages;
         } else {
@@ -254,7 +254,7 @@ class LitPagination extends LitElement{
     }
 
     onNext(event) {
-        this.page = this.page < this.pages ? this.page + 1 : this.pages;
+        this.page = this.page < this.pages ? parseInt(this.page) + 1 : this.pages;
     }
     onBegin(event) {
         this.page = 1;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lit-pagination",
   "main": "lit-pagination.js",
   "module": "lit-pagination.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Klaudeta/lit-pagination.git"


### PR DESCRIPTION
Solved issue that when calculating lastIndex actually a string concatenation was done between page number and size. I.e. for page 1 the lastIndex would be 15 instead of 6, for 2 lastIndex would be 25 instead of 7 and so on. Use parseInt() to make sure page and size are added numerically.